### PR TITLE
Remove RAM limit for Duckdb

### DIFF
--- a/utils/main_functions.py
+++ b/utils/main_functions.py
@@ -163,8 +163,7 @@ def merge_task_files(
     # Use duckdb here bc polars apparently can't read multiple json files unless they are
     # ndjson, and these are not
     conn = duckdb.connect()
-    # Make sure we stay under the RAM limit. A Function node has 1.5GB RAM
-    conn.sql("SET memory_limit = '1.1GB';")
+
     prod_runs: pl.DataFrame = (
         # Find all the metadata files
         conn.sql(f"SELECT * FROM read_json('{md_path}', auto_detect=true)")


### PR DESCRIPTION
Container apps are now configured with 4GB RAM and 8GB of ephemeral storage. This _should_ allow us to use the default duckdb memory settings and speed up processing.