### PR TITLE
Allow filtering on production date

### DIFF
--- a/cfa_rt_postprocessing/cli.py
+++ b/cfa_rt_postprocessing/cli.py
@@ -24,6 +24,12 @@ def main(
             help="Maximum run UTC datetime to consider for merging. UTC tz added by script."
         ),
     ],
+    prod_date: Annotated[
+        datetime | None,
+        typer.Option(
+            help="A production date to filter on. If not passed in, not filtered by production_date"
+        ),
+    ] = None,
     rt_output_container_name: Annotated[
         str,
         typer.Option(
@@ -47,10 +53,17 @@ def main(
     # parseddatetime objects
     min_runat = min_runat.replace(tzinfo=timezone.utc)
     max_runat = max_runat.replace(tzinfo=timezone.utc)
+
+    # Typer apparently does not know how to parse a date, so we need to grab just the
+    # date portion of the prod_date datetime object
+    if prod_date is not None:
+        prod_date = prod_date.date()  # type: ignore
+
     merge_and_render_anomaly(
         release_name=release_name,
         min_runat=min_runat,
         max_runat=max_runat,
+        prod_date=prod_date,
         rt_output_container_name=rt_output_container_name,
         post_process_container_name=post_process_container_name,
         overwrite_blobs=overwrite_blobs,

--- a/cfa_rt_postprocessing/main_functions.py
+++ b/cfa_rt_postprocessing/main_functions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from shutil import rmtree
 
@@ -64,6 +64,7 @@ def merge_and_render_anomaly(
     release_name: str,
     min_runat: datetime,
     max_runat: datetime,
+    prod_date: date | None = None,
     rt_output_container_name: str = "nssp_rt",
     post_process_container_name: str = "nssp-rt-post-process",
     overwrite_blobs: bool = False,
@@ -188,6 +189,10 @@ def merge_and_render_anomaly(
             + ".parquet",
         )
     )
+    # Filter by the production date if provided
+    if prod_date is not None:
+        prod_runs = prod_runs.filter(pl.col.production_date.eq(prod_date))
+
     console.log(f"Found {len(prod_runs)} tasks to merge")
     # === Create the <release-name>/interal_review/<job_id>/ folders ===============
     # Get the unique job-ids
@@ -351,7 +356,10 @@ def merge_and_render_anomaly(
                     overwrite=overwrite_blobs,
                 )
             console.log(
-                f"Uploaded the covid anomaly report to {output_ctr_client.url}/{covid_report}"
+                (
+                    f"Uploaded the covid anomaly report to {output_ctr_client.url}/{covid_report}"
+                    f" and to {output_ctr_client.url}/latest_anomaly_report_covid.html"
+                )
             )
 
             # To /latest_anomaly_report_covid.html in the container


### PR DESCRIPTION
This allows the user to optionally filter on the `production_date` as listed in the model run's metadata file.

This **does not** yet apply this filter to the server entry point, see #29 for tracking.