### PR TITLE
Filter plot to only at or before report date

### DIFF
--- a/cfa_rt_postprocessing/anomaly_report.qmd
+++ b/cfa_rt_postprocessing/anomaly_report.qmd
@@ -12,6 +12,7 @@ jupyter: python3
 # https://quarto.org/docs/computations/parameters.html
 summary_file = ""
 samples_file = ""
+metadata_file = ""
 disease = ""
 ```
 ```{python}
@@ -21,6 +22,9 @@ if summary_file == "":
 
 if samples_file == "":
     raise ValueError("No paramenter handed in for samples file location")
+
+if metadata_file == "":
+    raise ValueError("No paramenter handed in for metadata file location")
 
 if disease == "":
     raise ValueError("No disease paramenter handed in")
@@ -35,12 +39,20 @@ import polars as pl
 from plotting.rt import plot_rt
 
 summary = pl.read_parquet(summary_file)
+metadata = pl.read_parquet(metadata_file)
+
+# This is likely all from a single report date. Grab it, and warn if not.
+report_dates = metadata.get_column("report_date").unique()
+if len(report_dates) != 1:
+    raise ValueError("Multiple report dates found in metadata")
+
+report_date = report_dates[0]
 
 # Gather the set of unique states
 states: list[str] = summary.get_column("geo_value").unique().sort().to_list()
 
 # Plot each state
-plots = [plot_rt(summary, state, disease) for state in states]
+plots = [plot_rt(summary, state, disease, report_date) for state in states]
 # The .resolve_scale(color="independent") adds a legend to each plot, as opposed to a
 # single legend for all plots
 alt.concat(*plots, columns=2).resolve_scale(color="independent")

--- a/cfa_rt_postprocessing/main_functions.py
+++ b/cfa_rt_postprocessing/main_functions.py
@@ -307,8 +307,8 @@ def merge_and_render_anomaly(
 
     # Upload the metadata df as a parquet file
     md_file = internal_review / "metadata.parquet"
+    prod_runs.write_parquet(md_file)
     try:
-        prod_runs.write_parquet(md_file)
         with md_file.open("rb") as data:
             output_ctr_client.upload_blob(
                 name=str(md_file),

--- a/cfa_rt_postprocessing/main_functions.py
+++ b/cfa_rt_postprocessing/main_functions.py
@@ -306,8 +306,8 @@ def merge_and_render_anomaly(
         console.log(f"Failed to upload the samples: {e}")
 
     # Upload the metadata df as a parquet file
+    md_file = internal_review / "metadata.parquet"
     try:
-        md_file = internal_review / "metadata.parquet"
         prod_runs.write_parquet(md_file)
         with md_file.open("rb") as data:
             output_ctr_client.upload_blob(
@@ -330,6 +330,7 @@ def merge_and_render_anomaly(
             desired_output_location=covid_report,
             summary_loc=final_summaries,
             samples_loc=final_samples,
+            metadata_file=md_file,
         )
     except Exception as e:
         console.log(f"Failed to render the COVID-19 anomaly report: {e}")
@@ -341,6 +342,7 @@ def merge_and_render_anomaly(
             desired_output_location=flu_report,
             summary_loc=final_summaries,
             samples_loc=final_samples,
+            metadata_file=md_file,
         )
     except Exception as e:
         console.log(f"Failed to render the Influenza anomaly report: {e}")
@@ -414,6 +416,7 @@ def render_report(
     desired_output_location: Path,
     summary_loc: Path,
     samples_loc: Path,
+    metadata_file: Path,
     unrendered_location: Path = Path("cfa_rt_postprocessing/anomaly_report.qmd"),
 ):
     quarto.render(
@@ -421,6 +424,7 @@ def render_report(
         execute_params={
             "summary_file": str(summary_loc.absolute()),
             "samples_file": str(samples_loc.absolute()),
+            "metadata_file": str(metadata_file.absolute()),
             "disease": disease,
         },
     )

--- a/cfa_rt_postprocessing/plotting/rt.py
+++ b/cfa_rt_postprocessing/plotting/rt.py
@@ -1,8 +1,15 @@
+from datetime import date
+
 import altair as alt
 import polars as pl
 
 
-def plot_rt(summary: pl.DataFrame, state: str, disease: str) -> alt.LayerChart:
+def plot_rt(
+    summary: pl.DataFrame,
+    state: str,
+    disease: str,
+    repot_date: date,
+) -> alt.LayerChart:
     """
     Plot the Rt 95% width Rt estimates as a band plot, with the median as a line in the
     middle.
@@ -13,6 +20,7 @@ def plot_rt(summary: pl.DataFrame, state: str, disease: str) -> alt.LayerChart:
             pl.col.geo_value.is_in((state, "US")),
             pl.col.disease.eq(disease),
             pl.col("_variable").eq("Rt"),
+            pl.col.reference_date.le(repot_date),
         )
         # To ensure the US is always plotted underneath the value from the state, sort
         # the table so that the US always comes first, meaning it gets plotted first,


### PR DESCRIPTION
Use the `report_date` listed in the metadata to cutoff the uninteresting parts of the Rt plot.

## Before
![image](https://github.com/user-attachments/assets/1b1b9805-15ac-4a95-ae10-98a95cc9ae38)


## After
![image](https://github.com/user-attachments/assets/5b762e83-7cbb-4ccc-b8ea-9456fb54bdcb)
